### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,26 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+      - uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ This project provides a schema and context system for representing personality t
 
 ## License
 MIT - see the [LICENSE](LICENSE) file for details.
+
+## GitHub Pages
+
+This repository is configured to publish the contents of the `docs/` folder via GitHub Pages. Once enabled in the repository settings, the schema definitions will be accessible at a URL like `https://<username>.github.io/digital-persona/`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# Digital Persona Schema
+
+This GitHub Pages site hosts the JSON-LD contexts, JSON Schemas and vocabulary files from the `main` branch of the repository.
+
+## Available Files
+
+- [context/personality-context.jsonld](../schema/context/personality-context.jsonld)
+- [schemas/personality-traits.json](../schema/schemas/personality-traits.json)
+- [ontologies/trait-vocabulary.md](../schema/ontologies/trait-vocabulary.md)
+
+These files can be fetched directly via the `https://{username}.github.io/digital-persona/` URL after GitHub Pages is enabled.


### PR DESCRIPTION
## Summary
- publish schema via GitHub Pages using Pages action
- document the schema site in README
- add a docs/ folder with links to schema files
- fix workflow to use latest Pages actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685856f15a6083238b3fa77e413e7530