### PR TITLE
Fix GitHub Pages schema links

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
+      - name: Copy schema files
+        run: |
+          mkdir -p docs
+          cp -r schema docs/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ MIT - see the [LICENSE](LICENSE) file for details.
 
 ## GitHub Pages
 
-This repository is configured to publish the contents of the `docs/` folder via GitHub Pages. Once enabled in the repository settings, the schema definitions will be accessible at a URL like `https://<username>.github.io/digital-persona/`.
+This repository publishes the contents of the `docs/` folder via GitHub Pages. You can view the hosted files at [https://hackshaven.github.io/digital-persona/](https://hackshaven.github.io/digital-persona/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@ This GitHub Pages site hosts the JSON-LD contexts, JSON Schemas and vocabulary f
 
 ## Available Files
 
-- [context/personality-context.jsonld](../schema/context/personality-context.jsonld)
-- [schemas/personality-traits.json](../schema/schemas/personality-traits.json)
-- [ontologies/trait-vocabulary.md](../schema/ontologies/trait-vocabulary.md)
+- [context/personality-context.jsonld](schema/context/personality-context.jsonld)
+- [schemas/personality-traits.json](schema/schemas/personality-traits.json)
+- [ontologies/trait-vocabulary.md](schema/ontologies/trait-vocabulary.md)
 
-These files can be fetched directly via the `https://{username}.github.io/digital-persona/` URL after GitHub Pages is enabled.
+These files can be fetched directly via [GitHub Pages](https://hackshaven.github.io/digital-persona/).


### PR DESCRIPTION
## Summary
- copy schema directory into docs during Pages deploy
- fix links in docs to use the copied files
- add real GitHub Pages URL to README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68585e76229083238cb5de464d1cf5fd