### PR TITLE
Staging

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,9 +18,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/configure-pages@v1
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
-      - uses: actions/deploy-pages@v1
+      - uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
+      - name: Copy schema files
+        run: |
+          mkdir -p docs
+          cp -r schema docs/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ MIT - see the [LICENSE](LICENSE) file for details.
 
 ## GitHub Pages
 
-This repository is configured to publish the contents of the `docs/` folder via GitHub Pages. Once enabled in the repository settings, the schema definitions will be accessible at a URL like `https://<username>.github.io/digital-persona/`.
+This repository publishes the contents of the `docs/` folder via GitHub Pages. You can view the hosted files at [https://hackshaven.github.io/digital-persona/](https://hackshaven.github.io/digital-persona/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@ This GitHub Pages site hosts the JSON-LD contexts, JSON Schemas and vocabulary f
 
 ## Available Files
 
-- [context/personality-context.jsonld](../schema/context/personality-context.jsonld)
-- [schemas/personality-traits.json](../schema/schemas/personality-traits.json)
-- [ontologies/trait-vocabulary.md](../schema/ontologies/trait-vocabulary.md)
+- [context/personality-context.jsonld](schema/context/personality-context.jsonld)
+- [schemas/personality-traits.json](schema/schemas/personality-traits.json)
+- [ontologies/trait-vocabulary.md](schema/ontologies/trait-vocabulary.md)
 
-These files can be fetched directly via the `https://{username}.github.io/digital-persona/` URL after GitHub Pages is enabled.
+These files can be fetched directly via [GitHub Pages](https://hackshaven.github.io/digital-persona/).


### PR DESCRIPTION
This pull request updates the GitHub Pages configuration and documentation to improve usability and accessibility. The most important changes include automating the schema file copying process, updating URLs in the documentation to reflect the hosted GitHub Pages site, and fixing relative paths in the `docs/index.md` file.

### GitHub Pages Configuration:

* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5R23-R26): Added a step to copy schema files into the `docs/` directory as part of the workflow, ensuring all necessary files are included in the published GitHub Pages site.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23): Updated the description of the GitHub Pages site to include the direct URL to the hosted files (`https://hackshaven.github.io/digital-persona/`).
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L7-R11): Corrected relative paths to schema files and replaced the placeholder URL with the actual GitHub Pages URL.