### PR TITLE
Fix deploy workflow environment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,8 @@ concurrency:
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/


### PR DESCRIPTION
## Summary
- add default ignores for Python cache directories
- specify the `github-pages` environment for the Pages deploy job

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68586312b458832385cda0056ae49f42