### PR TITLE
Improve conversation flow in interview script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This project provides a schema and context system for representing personality t
 - `src/digital_persona/` – Python package containing utilities
 - `src/digital_persona/interview.py` – Interview assistant that derives
   personality traits from unstructured user data
+- `docs/` – Research papers used as additional prompt context and published via
+  GitHub Pages
 
 ## Example: Interview Script
 
@@ -156,3 +158,4 @@ MIT - see the [LICENSE](LICENSE) file for details.
 ## GitHub Pages
 
 This repository publishes the research and schema via GitHub Pages. You can view the hosted files at [https://hackshaven.github.io/digital-persona/](https://hackshaven.github.io/digital-persona/).
+The Markdown papers inside `docs/` are loaded as extra context for interview prompts and are also published on this site so they are easy to access online.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Which outputs JSON similar to:
 ```json
 {
   "unstructuredData": "Email: I'm looking forward to the team retreat next month.\nJournal: I've been worried about meeting deadlines but remain optimistic.",
+  "userID": "anon-1234",
   "interview": [
     {"question": "How do you manage approaching deadlines?", "answer": "I set priorities and talk with the team."},
     {"question": "What steps do you take to resolve conflicts at work?", "answer": "I try to consider everyone's viewpoint."},
@@ -100,16 +101,15 @@ Which outputs JSON similar to:
     "significance": null,
     "copingStyle": null
   },
-  "psychologicalSummary": "Based on your email about the upcoming retreat and notes about deadline worries, you seem optimistic and cooperative though somewhat anxious about performance",
+  "psychologicalSummary": "Assigned openness=0.63 for your interest in new ideas, conscientiousness=0.72 because you plan tasks carefully, extraversion=0.55 since you enjoy team activities, agreeableness=0.68 due to collaborative comments, and neuroticism=0.40 reflecting only mild worry",
   "timestamp": "2024-05-04T15:32:10Z"
 }
 ```
 
 The exact questions and scores will vary depending on the language model and
-your responses.
-If the interview doesn't provide enough detail for a particular trait or other
-attribute, the corresponding value will appear as `null` in the JSON output. The profile also includes
-an ISO 8601 `timestamp` marking when the interview was completed.
+your responses. Missing details appear as `null`. Each profile also includes an
+anonymous `userID` and a psychological summary describing why each attribute was
+inferred, along with an ISO 8601 `timestamp` marking when the interview was completed.
 
 ### Command Line Usage
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ This project provides a schema and context system for representing personality t
 
 The script can analyze diary entries, emails, or other free-form text. It then
 poses follow-up questions and returns a profile matching the
-`personality-interview.json` schema, which includes both the interview data and
-trait scores.
+`personality-interview.json` schema, which includes the interview data,
+trait scores, and optional MBTI, Dark Triad, MMPI, goal, value, and narrative
+information.
 
 ```python
 from digital_persona.interview import PersonalityInterviewer
@@ -73,15 +74,41 @@ Which outputs JSON similar to:
     "honestyHumility": 0.59,
     "emotionality": null
   },
+  "darkTriad": {
+    "narcissism": null,
+    "machiavellianism": null,
+    "psychopathy": null
+  },
+  "mbti": {"mbti": null},
+  "mmpi": {
+    "hypochondriasis": null,
+    "depression": null,
+    "hysteria": null,
+    "psychopathicDeviate": null,
+    "masculinityFemininity": null,
+    "paranoia": null,
+    "psychasthenia": null,
+    "schizophrenia": null,
+    "hypomania": null,
+    "socialIntroversion": null
+  },
+  "goal": {"description": null, "status": null, "targetDate": null},
+  "value": {"valueName": null, "importance": null},
+  "narrative": {
+    "eventRef": null,
+    "narrativeTheme": null,
+    "significance": null,
+    "copingStyle": null
+  },
   "psychologicalSummary": "Based on your email about the upcoming retreat and notes about deadline worries, you seem optimistic and cooperative though somewhat anxious about performance",
   "timestamp": "2024-05-04T15:32:10Z"
- }
+}
 ```
 
 The exact questions and scores will vary depending on the language model and
 your responses.
-If the interview doesn't provide enough detail for a particular trait, that
-trait value will appear as `null` in the JSON output. The profile also includes
+If the interview doesn't provide enough detail for a particular trait or other
+attribute, the corresponding value will appear as `null` in the JSON output. The profile also includes
 an ISO 8601 `timestamp` marking when the interview was completed.
 
 ### Command Line Usage
@@ -97,8 +124,13 @@ $ digital-persona-interview my_notes.txt -p openai
 This launches an interactive session where you answer the generated questions
 and any clarifying follow-ups, then receive a JSON profile at the end. When
 answering, you can enter multiple lines; press Enter on an empty line when you
-are finished. If you do not specify `--questions`, the interviewer asks roughly
-one question per trait to gather adequate information.
+are finished. A short summary of your input text will be shown at the start and
+before each question you'll see a brief note explaining why that question
+relates to what you shared. You may end the interview early at any time by
+typing `/end` on a line by itself. If you do not specify `--questions`, the
+interviewer picks about half as many questions as there are traits and tries to
+cover multiple traits per question. At the start you'll see the full list of
+questions along with your progress as you answer them.
 
 The interviewer defaults to OpenAI's API and reads your `OPENAI_API_KEY` from the
 environment. You can instead talk to a local Ollama server by passing

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ print("\n".join(questions))
 # What hobbies help you relax?
 # The interviewer may add clarifying follow-ups such as:
 # Could you give an example of how you prioritize tasks?
+# Up to two short follow-up questions may be asked to clarify each answer.
 
 # After answering the questions (including any follow-ups), gather the Q&A pairs
 qa_pairs = [
@@ -129,7 +130,8 @@ answering, you can enter multiple lines; press Enter on an empty line when you
 are finished. A short summary of your input text will be shown at the start and
 before each question you'll see a brief note explaining why that question
 relates to what you shared. Follow-up questions include a similar sentence
-explaining how they connect to your previous answer and notes. You may end the interview early at any time by
+explaining how they connect to your previous answer and notes. No more than two
+follow-up questions are asked for each main question. You may end the interview early at any time by
 typing `/end` on a line by itself. If you do not specify `--questions`, the
 interviewer picks about half as many questions as there are traits and tries to
 cover multiple traits per question. At the start you'll see the full list of

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ and any clarifying follow-ups, then receive a JSON profile at the end. When
 answering, you can enter multiple lines; press Enter on an empty line when you
 are finished. A short summary of your input text will be shown at the start and
 before each question you'll see a brief note explaining why that question
-relates to what you shared. You may end the interview early at any time by
+relates to what you shared. Follow-up questions include a similar sentence
+explaining how they connect to your previous answer and notes. You may end the interview early at any time by
 typing `/end` on a line by itself. If you do not specify `--questions`, the
 interviewer picks about half as many questions as there are traits and tries to
 cover multiple traits per question. At the start you'll see the full list of

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ interviewer picks about half as many questions as there are traits and tries to
 cover multiple traits per question. At the start you'll see the full list of
 questions along with your progress as you answer them.
 
+To quickly test without providing real answers, run the command with
+`--dry-run`. In this mode the language model simulates interview answers based
+on your notes. You'll see the entire exchange printed before the resulting JSON
+profile.
+
 The interviewer defaults to OpenAI's API and reads your `OPENAI_API_KEY` from the
 environment. You can instead talk to a local Ollama server by passing
 `-p ollama` and setting `OLLAMA_BASE_URL` (default `http://localhost:11434`) and

--- a/schema/schemas/personality-interview.json
+++ b/schema/schemas/personality-interview.json
@@ -15,6 +15,7 @@
                 "required": ["question", "answer"]
             }
         },
+        "userID": {"type": "string", "description": "Anonymous user identifier"},
         "traits": {"$ref": "./personality-traits.json"},
         "darkTriad": {"$ref": "./dark-triad.json"},
         "mbti": {"$ref": "./mbti-type.json"},
@@ -28,6 +29,7 @@
     "required": [
         "unstructuredData",
         "interview",
+        "userID",
         "traits",
         "psychologicalSummary",
         "timestamp"

--- a/schema/schemas/personality-interview.json
+++ b/schema/schemas/personality-interview.json
@@ -1,29 +1,35 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Personality Interview Result",
-  "type": "object",
-  "properties": {
-    "unstructuredData": {"type": "string"},
-    "interview": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "question": {"type": "string"},
-          "answer": {"type": "string"}
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Personality Interview Result",
+    "type": "object",
+    "properties": {
+        "unstructuredData": {"type": "string"},
+        "interview": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "question": {"type": "string"},
+                    "answer": {"type": "string"}
+                },
+                "required": ["question", "answer"]
+            }
         },
-        "required": ["question", "answer"]
-      }
+        "traits": {"$ref": "./personality-traits.json"},
+        "darkTriad": {"$ref": "./dark-triad.json"},
+        "mbti": {"$ref": "./mbti-type.json"},
+        "mmpi": {"$ref": "./mmpi-scales.json"},
+        "goal": {"$ref": "./goal-schema.json"},
+        "value": {"$ref": "./values-schema.json"},
+        "narrative": {"$ref": "./narrative-schema.json"},
+        "psychologicalSummary": {"type": "string"},
+        "timestamp": {"type": "string", "format": "date-time"}
     },
-    "traits": {"$ref": "./personality-traits.json"},
-    "psychologicalSummary": {"type": "string"},
-    "timestamp": {"type": "string", "format": "date-time"}
-  },
-  "required": [
-    "unstructuredData",
-    "interview",
-    "traits",
-    "psychologicalSummary",
-    "timestamp"
-  ]
+    "required": [
+        "unstructuredData",
+        "interview",
+        "traits",
+        "psychologicalSummary",
+        "timestamp"
+    ]
 }

--- a/schema/tests/test_all_schemas.py
+++ b/schema/tests/test_all_schemas.py
@@ -62,6 +62,7 @@ SCHEMA_EXAMPLES = {
         "interview": [
             {"question": "How do you handle stress?", "answer": "I meditate"}
         ],
+        "userID": "anon-sample",
         "traits": {
             "openness": 0.5,
             "conscientiousness": 0.7,

--- a/schema/tests/test_all_schemas.py
+++ b/schema/tests/test_all_schemas.py
@@ -9,7 +9,7 @@ warnings.filterwarnings(
     "ignore",
     category=DeprecationWarning,
     module="jsonschema",
-    message="jsonschema.RefResolver is deprecated"
+    message="jsonschema.RefResolver is deprecated",
 )
 
 SCHEMA_EXAMPLES = {
@@ -59,7 +59,9 @@ SCHEMA_EXAMPLES = {
     },
     "personality-interview.json": {
         "unstructuredData": "Email snippet...",
-        "interview": [{"question": "How do you handle stress?", "answer": "I meditate"}],
+        "interview": [
+            {"question": "How do you handle stress?", "answer": "I meditate"}
+        ],
         "traits": {
             "openness": 0.5,
             "conscientiousness": 0.7,
@@ -69,8 +71,41 @@ SCHEMA_EXAMPLES = {
             "honestyHumility": 0.6,
             "emotionality": 0.4,
         },
+        "darkTriad": {
+            "narcissism": 0.5,
+            "machiavellianism": 0.4,
+            "psychopathy": 0.3,
+        },
+        "mbti": {"mbti": "INTJ"},
+        "mmpi": {
+            "hypochondriasis": 0.2,
+            "depression": 0.3,
+            "hysteria": 0.1,
+            "psychopathicDeviate": 0.4,
+            "masculinityFemininity": 0.5,
+            "paranoia": 0.2,
+            "psychasthenia": 0.3,
+            "schizophrenia": 0.25,
+            "hypomania": 0.45,
+            "socialIntroversion": 0.35,
+        },
+        "goal": {
+            "description": "Finish project",
+            "status": "in-progress",
+            "targetDate": "2025-12-31",
+        },
+        "value": {
+            "valueName": "Curiosity",
+            "importance": 0.9,
+        },
+        "narrative": {
+            "eventRef": "urn:uuid:1234",
+            "narrativeTheme": "http://example.org/theme/resilience",
+            "significance": "high",
+            "copingStyle": "problem-focused",
+        },
         "psychologicalSummary": "Calm and balanced individual",
-        "timestamp": "2024-01-01T12:00:00Z"
+        "timestamp": "2024-01-01T12:00:00Z",
     },
 }
 
@@ -79,7 +114,9 @@ def load_schema_with_resolver(schema_path: Path):
     with open(schema_path, encoding="utf-8") as f:
         schema = json.load(f)
 
-    resolver = jsonschema.RefResolver(base_uri=schema_path.resolve().as_uri(), referrer=schema)
+    resolver = jsonschema.RefResolver(
+        base_uri=schema_path.resolve().as_uri(), referrer=schema
+    )
     validator_class = jsonschema.validators.validator_for(schema)
     validator = validator_class(schema, resolver=resolver)
     return validator

--- a/src/digital_persona/interview.py
+++ b/src/digital_persona/interview.py
@@ -331,14 +331,15 @@ class PersonalityInterviewer:
             follow = self.generate_followup(q, answer)
 
             while follow and follow_ups < 2:
-                # Fuzzy suppression: check if this follow-up is too similar to the previous
-                if prev_follow:
-                    similarity = difflib.SequenceMatcher(
-                        None, follow, prev_follow
-                    ).ratio()
-                    if similarity > 0.9:
-                        break  # Too similar to the last one
                 try:
+                    # Fuzzy suppression: check if this follow-up is too similar to the previous
+                    if prev_follow:
+                        similarity = difflib.SequenceMatcher(
+                            None, follow, prev_follow
+                        ).ratio()
+                        if similarity > 0.9:
+                            break  # Too similar to the last one
+
                     expl = self.explain_followup(follow, q, unstructured_data)
                     print(f"   ↳ {expl}")
                     follow_answer = self._collect_multiline_answer(follow)

--- a/src/digital_persona/interview.py
+++ b/src/digital_persona/interview.py
@@ -98,6 +98,20 @@ class PersonalityInterviewer:
         ]
         return self.llm.invoke(msg).content.strip()
 
+    def explain_followup(
+        self, followup: str, original_question: str, unstructured_data: str
+    ) -> str:
+        """Explain why a follow-up question is being asked."""
+        prompt = (
+            "Explain in one short sentence how this follow-up builds on the original question and the user's notes."
+            "\nNotes:\n{data}\nOriginal question: {orig}\nFollow-up: {fup}"
+        ).format(data=unstructured_data, orig=original_question, fup=followup)
+        msg = [
+            SystemMessage(content="Friendly explanation."),
+            HumanMessage(content=prompt),
+        ]
+        return self.llm.invoke(msg).content.strip()
+
     def generate_questions(self, unstructured_data: str) -> List[str]:
         """Generate interview questions to clarify the user's personality."""
         prompt = (
@@ -284,6 +298,8 @@ class PersonalityInterviewer:
                     if similarity > 0.9:
                         break  # Too similar to the last one
                 try:
+                    expl = self.explain_followup(follow, q, unstructured_data)
+                    print(f"   ↳ {expl}")
                     follow_answer = self._collect_multiline_answer(follow)
                 except EarlyFinish:
                     print("\nInterview finished early. Generating profile...\n")

--- a/src/digital_persona/interview.py
+++ b/src/digital_persona/interview.py
@@ -257,34 +257,46 @@ class PersonalityInterviewer:
                 traits[name] = value
 
         dark_triad = {k: None for k in self.dark_triad_fields}
-        for name, value in (result.get("darkTriad") or {}).items():
-            if name in dark_triad:
-                dark_triad[name] = value
+        dark_data = result.get("darkTriad")
+        if isinstance(dark_data, dict):
+            for name, value in dark_data.items():
+                if name in dark_triad:
+                    dark_triad[name] = value
 
         mbti = {k: None for k in self.mbti_fields}
-        for name, value in (result.get("mbti") or {}).items():
-            if name in mbti:
-                mbti[name] = value
+        mbti_data = result.get("mbti")
+        if isinstance(mbti_data, dict):
+            for name, value in mbti_data.items():
+                if name in mbti:
+                    mbti[name] = value
 
         mmpi = {k: None for k in self.mmpi_fields}
-        for name, value in (result.get("mmpi") or {}).items():
-            if name in mmpi:
-                mmpi[name] = value
+        mmpi_data = result.get("mmpi")
+        if isinstance(mmpi_data, dict):
+            for name, value in mmpi_data.items():
+                if name in mmpi:
+                    mmpi[name] = value
 
         goal = {k: None for k in self.goal_fields}
-        for name, value in (result.get("goal") or {}).items():
-            if name in goal:
-                goal[name] = value
+        goal_data = result.get("goal")
+        if isinstance(goal_data, dict):
+            for name, value in goal_data.items():
+                if name in goal:
+                    goal[name] = value
 
         value_obj = {k: None for k in self.value_fields}
-        for name, val in (result.get("value") or {}).items():
-            if name in value_obj:
-                value_obj[name] = val
+        val_data = result.get("value")
+        if isinstance(val_data, dict):
+            for name, val in val_data.items():
+                if name in value_obj:
+                    value_obj[name] = val
 
         narrative = {k: None for k in self.narrative_fields}
-        for name, val in (result.get("narrative") or {}).items():
-            if name in narrative:
-                narrative[name] = val
+        narr_data = result.get("narrative")
+        if isinstance(narr_data, dict):
+            for name, val in narr_data.items():
+                if name in narrative:
+                    narrative[name] = val
 
         return {
             "unstructuredData": unstructured_data,

--- a/src/digital_persona/interview.py
+++ b/src/digital_persona/interview.py
@@ -22,6 +22,9 @@ class EarlyFinish(Exception):
 
 END_COMMAND = "/end"
 
+# At most this many clarification follow-ups will be asked for each question.
+MAX_FOLLOWUPS = 2
+
 
 class PersonalityInterviewer:
     """Chat-based interviewer that asks questions and clarification follow-ups."""
@@ -211,7 +214,7 @@ class PersonalityInterviewer:
             prev_follow = None
             follow = self.generate_followup(q, answer)
 
-            while follow and follow_ups < 2:
+            while follow and follow_ups < MAX_FOLLOWUPS:
                 try:
                     if prev_follow:
                         similarity = difflib.SequenceMatcher(None, follow, prev_follow).ratio()

--- a/src/digital_persona/interview.py
+++ b/src/digital_persona/interview.py
@@ -206,32 +206,32 @@ class PersonalityInterviewer:
                 traits[name] = value
 
         dark_triad = {k: None for k in self.dark_triad_fields}
-        for name, value in result.get("darkTriad", {}).items():
+        for name, value in (result.get("darkTriad") or {}).items():
             if name in dark_triad:
                 dark_triad[name] = value
 
         mbti = {k: None for k in self.mbti_fields}
-        for name, value in result.get("mbti", {}).items():
+        for name, value in (result.get("mbti") or {}).items():
             if name in mbti:
                 mbti[name] = value
 
         mmpi = {k: None for k in self.mmpi_fields}
-        for name, value in result.get("mmpi", {}).items():
+        for name, value in (result.get("mmpi") or {}).items():
             if name in mmpi:
                 mmpi[name] = value
 
         goal = {k: None for k in self.goal_fields}
-        for name, value in result.get("goal", {}).items():
+        for name, value in (result.get("goal") or {}).items():
             if name in goal:
                 goal[name] = value
 
         value_obj = {k: None for k in self.value_fields}
-        for name, val in result.get("value", {}).items():
+        for name, val in (result.get("value") or {}).items():
             if name in value_obj:
                 value_obj[name] = val
 
         narrative = {k: None for k in self.narrative_fields}
-        for name, val in result.get("narrative", {}).items():
+        for name, val in (result.get("narrative") or {}).items():
             if name in narrative:
                 narrative[name] = val
 

--- a/src/digital_persona/interview.py
+++ b/src/digital_persona/interview.py
@@ -7,6 +7,7 @@ import os
 import difflib
 
 from datetime import datetime, timezone
+import uuid
 from pathlib import Path
 from typing import List
 
@@ -225,8 +226,9 @@ class PersonalityInterviewer:
         prompt = (
             "You are a psychologist creating a personality profile. "
             "Given the unstructured data and interview Q&A below, output a JSON object "
-            "with a 'psychologicalSummary' string and objects for 'traits', 'darkTriad', 'mbti', "
-            "'mmpi', 'goal', 'value', and 'narrative'. Scores should be between 0.0 and 1.0 where applicable. "
+            "with a 'psychologicalSummary' that lists each assigned attribute, its value, "
+            "and a short explanation for why it was inferred. Include objects for 'traits', "
+            "'darkTriad', 'mbti', 'mmpi', 'goal', 'value', and 'narrative'. Scores should be between 0.0 and 1.0 where applicable. "
             "Return null for any attribute you cannot infer. Only output valid JSON.\n\n"
             "Unstructured data:\n{data}\n\nQ&A:\n{qa}"
         )
@@ -298,9 +300,14 @@ class PersonalityInterviewer:
                 if name in narrative:
                     narrative[name] = val
 
+        user_id = result.get("userID")
+        if not isinstance(user_id, str) or not user_id.strip():
+            user_id = f"user-{uuid.uuid4().hex[:8]}"
+
         return {
             "unstructuredData": unstructured_data,
             "interview": self._qa_list(qa_pairs),
+            "userID": user_id,
             "traits": traits,
             "darkTriad": dark_triad,
             "mbti": mbti,

--- a/src/digital_persona/interview.py
+++ b/src/digital_persona/interview.py
@@ -261,7 +261,7 @@ class PersonalityInterviewer:
             result = json.loads(clean)
 
         except json.JSONDecodeError:
-            raise ValueError(f"LLM did not return valid JSON: {response!r}")
+            raise ValueError(f"LLM response is not valid JSON: {response!r}")
 
         traits = self._extract_section(result, "traits", self.trait_names)
         dark_triad = self._extract_section(result, "darkTriad", self.dark_triad_fields)

--- a/tests/test_interviewer.py
+++ b/tests/test_interviewer.py
@@ -104,6 +104,7 @@ def test_profile_from_answers_builds_result():
             "goal": {"description": "Finish"},
             "value": {"valueName": "Curiosity"},
             "narrative": {"eventRef": "urn:uuid:1"},
+            "userID": "anon01",
             "psychologicalSummary": "Summary text",
         }
     )
@@ -114,6 +115,7 @@ def test_profile_from_answers_builds_result():
     profile = interviewer.profile_from_answers(data, qa_pairs)
     assert profile["unstructuredData"] == data
     assert profile["interview"] == [{"question": "How?", "answer": "Well"}]
+    assert profile["userID"] == "anon01"
     assert profile["traits"]["openness"] == 0.5
     assert profile["psychologicalSummary"] == "Summary text"
     assert profile["traits"]["emotionality"] is None
@@ -174,6 +176,7 @@ def test_run_allows_early_finish(monkeypatch):
             "traits": {"openness": 0.1, "conscientiousness": 0.2,
                         "extraversion": 0.3, "agreeableness": 0.4,
                         "neuroticism": 0.5, "honestyHumility": 0.6},
+            "userID": "anon02",
             "psychologicalSummary": "Done"
         })
     ]
@@ -186,6 +189,7 @@ def test_run_allows_early_finish(monkeypatch):
     profile = interviewer.run("notes")
     assert profile["interview"] == []
     assert profile["traits"]["openness"] == 0.1
+    assert profile["userID"] == "anon02"
 
 
 def test_run_simulated_generates_profile(capsys):
@@ -204,6 +208,7 @@ def test_run_simulated_generates_profile(capsys):
                 "neuroticism": 0.5,
                 "honestyHumility": 0.6,
             },
+            "userID": "anon03",
             "psychologicalSummary": "Done",
         })
     ]
@@ -213,6 +218,7 @@ def test_run_simulated_generates_profile(capsys):
     out = capsys.readouterr().out
     assert "Auto" in out
     assert profile["traits"]["openness"] == 0.1
+    assert profile["userID"] == "anon03"
 
 
 def test_profile_handles_string_sections():
@@ -239,3 +245,4 @@ def test_profile_handles_string_sections():
     assert profile["goal"] == {k: None for k in interviewer.goal_fields}
     assert profile["value"] == {k: None for k in interviewer.value_fields}
     assert profile["narrative"] == {k: None for k in interviewer.narrative_fields}
+    assert profile["userID"].startswith("user-")

--- a/tests/test_interviewer.py
+++ b/tests/test_interviewer.py
@@ -213,3 +213,29 @@ def test_run_simulated_generates_profile(capsys):
     out = capsys.readouterr().out
     assert "Auto" in out
     assert profile["traits"]["openness"] == 0.1
+
+
+def test_profile_handles_string_sections():
+    response_json = json.dumps(
+        {
+            "traits": {
+                "openness": 0.1,
+                "conscientiousness": 0.2,
+                "extraversion": 0.3,
+                "agreeableness": 0.4,
+                "neuroticism": 0.5,
+                "honestyHumility": 0.6,
+                "emotionality": 0.7,
+            },
+            "goal": "not an object",
+            "value": "also bad",
+            "narrative": "string",
+            "psychologicalSummary": "summary",
+        }
+    )
+    llm = StubLLM([response_json])
+    interviewer = PersonalityInterviewer(llm=llm)
+    profile = interviewer.profile_from_answers("notes", ["Q: ?\nA: !"])
+    assert profile["goal"] == {k: None for k in interviewer.goal_fields}
+    assert profile["value"] == {k: None for k in interviewer.value_fields}
+    assert profile["narrative"] == {k: None for k in interviewer.narrative_fields}

--- a/tests/test_interviewer.py
+++ b/tests/test_interviewer.py
@@ -39,7 +39,7 @@ if "langchain" not in sys.modules:
 # Project import (source assumed in ../src)
 # -------------------------------------------------------------------------
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-from digital_persona.interview import PersonalityInterviewer
+from digital_persona.interview import PersonalityInterviewer, MAX_FOLLOWUPS
 
 
 # -------------------------------------------------------------------------
@@ -69,6 +69,10 @@ def test_default_question_count_half_traits():
     interviewer = PersonalityInterviewer(llm=StubLLM([]))
     expected = max(3, (len(interviewer.trait_names) + 1) // 2)
     assert interviewer.num_questions == expected
+
+
+def test_max_followups_constant():
+    assert MAX_FOLLOWUPS == 2
 
 
 def test_generate_followup_handles_no_followup():

--- a/tests/test_interviewer.py
+++ b/tests/test_interviewer.py
@@ -186,3 +186,30 @@ def test_run_allows_early_finish(monkeypatch):
     profile = interviewer.run("notes")
     assert profile["interview"] == []
     assert profile["traits"]["openness"] == 0.1
+
+
+def test_run_simulated_generates_profile(capsys):
+    responses = [
+        "Summary",  # summarize_data
+        "Q1?",  # generate_questions
+        "Expl",  # explain_question
+        "Auto",  # simulate_answer
+        "NO FOLLOWUP",  # generate_followup
+        json.dumps({
+            "traits": {
+                "openness": 0.1,
+                "conscientiousness": 0.2,
+                "extraversion": 0.3,
+                "agreeableness": 0.4,
+                "neuroticism": 0.5,
+                "honestyHumility": 0.6,
+            },
+            "psychologicalSummary": "Done",
+        })
+    ]
+    llm = StubLLM(responses)
+    interviewer = PersonalityInterviewer(llm=llm, num_questions=1)
+    profile = interviewer.run_simulated("notes")
+    out = capsys.readouterr().out
+    assert "Auto" in out
+    assert profile["traits"]["openness"] == 0.1

--- a/tests/test_interviewer.py
+++ b/tests/test_interviewer.py
@@ -164,7 +164,7 @@ def test_profile_from_answers_invalid_json_error():
     interviewer = PersonalityInterviewer(llm=llm)
     with pytest.raises(ValueError) as exc:
         interviewer.profile_from_answers("ctx", ["Q: ?\nA: ."])
-    assert "not valid json" in str(exc.value)
+    assert "not valid JSON" in str(exc.value)
 
 
 def test_run_allows_early_finish(monkeypatch):


### PR DESCRIPTION
## Summary
- update README with new instructions for early exit and question explanations
- allow early termination of interview with `/end`
- summarize unstructured input and explain each question
- allow LLM-generated questions to cover multiple traits with dynamic count
- show planned questions and progress indicator during interview

## Testing
- `pip install jsonschema`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6859d1db85ec8323bfa80dbcee8023f7