### PR TITLE
Improve comments and test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ This repository defines structured formats (JSON-LD contexts, JSON Schemas, exam
 
 This data supports the development of digital personality clones, virtual assistants, and behavioral simulation agents.
 
+See `MISSION.md` for the guiding principles. When proposing or reviewing new features, ensure they align with that mission.
+
 ---
 
 ### 📁 Directory Overview

--- a/MISSION.md
+++ b/MISSION.md
@@ -1,0 +1,20 @@
+# Mission Statement
+
+The **Digital Persona** project aims to provide a safe, open framework for representing personality data.
+The research documents in the `docs/` directory outline existing standards for personal data and
+psychological testing. We build upon those papers to ensure our tools and schemas promote ethical,
+privacy‑respecting use of personality information.
+
+## Guiding Principles
+
+- **Do no harm** – Personality models and collected data must never be used to manipulate or exploit
+  people. This project should enhance personal insight, not enable coercion.
+- **User control** – Individuals own their data. Any systems built on this repository should clearly
+  explain how personal information is stored and give users full control over how it is shared or deleted.
+- **Security by design** – Protect data in transit and at rest. Adopt best practices for encryption,
+  access control, and secure coding.
+- **Open and distributed** – Favor open‑source components and decentralized architectures so that users
+  can run tools locally or on trusted infrastructure.
+
+All new features and pull requests must be checked against this mission statement to ensure
+alignment with these principles.

--- a/MISSION.md
+++ b/MISSION.md
@@ -1,20 +1,53 @@
-# Mission Statement
+# 🧠 Digital Persona Project: Mission Statement
 
-The **Digital Persona** project aims to provide a safe, open framework for representing personality data.
-The research documents in the `docs/` directory outline existing standards for personal data and
-psychological testing. We build upon those papers to ensure our tools and schemas promote ethical,
-privacy‑respecting use of personality information.
+**Digital Persona** is an open, collaborative initiative to build a modular AI system that emulates an individual’s personality in a privacy-first manner. The project's goal is to create a trusted “digital twin” — an AI persona that mirrors your decision-making, language style, memory, and preferences by learning from your own data (emails, chats, journals, transcripts, etc.) under your full control.
 
-## Guiding Principles
+## 🌟 Vision and Approach
 
-- **Do no harm** – Personality models and collected data must never be used to manipulate or exploit
-  people. This project should enhance personal insight, not enable coercion.
-- **User control** – Individuals own their data. Any systems built on this repository should clearly
-  explain how personal information is stored and give users full control over how it is shared or deleted.
-- **Security by design** – Protect data in transit and at rest. Adopt best practices for encryption,
-  access control, and secure coding.
-- **Open and distributed** – Favor open‑source components and decentralized architectures so that users
-  can run tools locally or on trusted infrastructure.
+The system integrates:
 
-All new features and pull requests must be checked against this mission statement to ensure
-alignment with these principles.
+- **Structured Long-Term Memory**  
+  Modeled after Stanford's generative agents, the Digital Persona uses a memory stream to recall and reflect on past events, creating continuity of personality over time.
+
+- **Modular Behavioral Architecture**  
+  Separate AI modules handle language, planning, emotion, and decision-making — allowing for easy upgrades and customization.
+
+- **Psychometric Trait Modeling**  
+  Using scientifically validated frameworks like the Big Five (OCEAN) and HEXACO, the AI is grounded in real personality psychology. Public-domain instruments like IPIP are used to derive trait vectors that influence behavior.
+
+- **Personal Narrative Integration**  
+  Inspired by narrative identity theory, the system models your life story — including formative events and core values — to deepen contextual understanding.
+
+- **Memory-Enhanced Reasoning**  
+  The persona evolves by incorporating new life events, adapting its behavior as your experiences change over time — all while preserving memory privacy and user intent.
+
+## 🛡️ Guiding Principles
+
+1. **User Control**: You own your data and your digital twin. You can inspect, edit, or erase anything.
+2. **Privacy-First Architecture**: Data stays local or in encrypted vaults. No raw data leaves your device without permission.
+3. **Informed Consent**: Permissions are granular and revocable. Consent is ongoing, not one-time.
+4. **Transparency & Explainability**: The system is open-source and designed to explain its behavior clearly and audibly.
+5. **Do No Harm**: AI personas are aligned with your well-being and subject to ethical constraints to avoid manipulation or misuse.
+6. **Clear Purpose & Limits**: The persona clarifies that it is not you and doesn’t replace your judgment — it augments it.
+
+## 🧬 Scientific and Technical Foundations
+
+- Draws on **Big Five and HEXACO** models.
+- Incorporates **IPIP trait inventories**.
+- Builds on prior research from **Stanford’s generative agents** and **Rewind.ai**.
+- Leverages open data standards and structured memory systems.
+- Bridges AI, psychology, and narrative identity frameworks for realistic simulation.
+
+## 🔄 Extensibility and Collaboration
+
+- **Open Source**: Anyone can contribute new modules or tools.
+- **Modular Design**: Components can be replaced or expanded independently.
+- **Community-Driven**: A governance model and advisory board ensure interdisciplinary input.
+- **Scientific Evaluation**: Ongoing testing, peer-reviewed results, and benchmark comparisons.
+- **Ethical Evolution**: The system adapts to evolving norms, legal frameworks, and social expectations.
+
+## 🚀 Our Commitment
+
+We’re building a digital companion that acts in your best interest, grows with you, and helps you think, plan, reflect, and express yourself — safely and authentically.
+
+**Together, let’s build a future where your closest AI is not just intelligent — it’s authentically you.**

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This project provides a schema and context system for representing personality t
 
 ![CI Status](https://github.com/Hackshaven/digital-persona/actions/workflows/test.yml/badge.svg?branch=main)
 
+## Mission Statement
+
+See [MISSION.md](MISSION.md) for the project's guiding principles. New features
+and pull requests should be checked against this statement to ensure they uphold
+ethical use, user control, and secure handling of personality data.
+
 ## Key Features
 - Big Five, HEXACO, MBTI, Dark Triad, and MMPI trait support
 - JSON-LD context for semantic personality tagging


### PR DESCRIPTION
## Summary
- clarify initialization and helper methods with docstrings
- explain follow-up deduplication logic
- expand unit tests to exercise schema loading, LLM selection, and follow-up logic
- add project mission statement with ethical guidelines
- mention mission statement in README and AGENTS docs

## Testing
- `pytest -q`
- `coverage run -m pytest -q && coverage report`


------
https://chatgpt.com/codex/tasks/task_b_685a0aacd63883239edc14723e77276f