### PR TITLE
Add encrypted local storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ $RECYCLE.BIN/
 !LICENSE
 !README.md
 !pyproject.toml
+docs/*.md
+!docs/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "referencing (>=0.36.2,<0.37.0)",
     "fastapi",
     "uvicorn",
+    "cryptography",
 ]
 
 [project.scripts]

--- a/src/digital_persona/secure_storage.py
+++ b/src/digital_persona/secure_storage.py
@@ -1,0 +1,39 @@
+import json
+import os
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+
+
+def get_fernet(base_dir: Path) -> Fernet:
+    """Return a Fernet instance using a key from env or ``base_dir``."""
+    key_env = os.getenv("PERSONA_KEY")
+    key_path = base_dir / ".persona.key"
+    if key_env:
+        key = key_env.encode()
+    else:
+        if key_path.exists():
+            key = key_path.read_bytes()
+        else:
+            key = Fernet.generate_key()
+            key_path.write_bytes(key)
+    return Fernet(key)
+
+
+def save_json_encrypted(data: dict, path: Path, fernet: Fernet) -> None:
+    """Encrypt ``data`` as JSON and write to ``path``."""
+    token = fernet.encrypt(json.dumps(data).encode("utf-8"))
+    path.write_bytes(token)
+
+
+def load_json_encrypted(path: Path, fernet: Fernet) -> dict:
+    """Load and decrypt JSON from ``path``.
+
+    Falls back to plain JSON if decryption fails (for backward compatibility).
+    """
+    raw = path.read_bytes()
+    try:
+        decrypted = fernet.decrypt(raw)
+        return json.loads(decrypted.decode("utf-8"))
+    except (InvalidToken, ValueError, json.JSONDecodeError):
+        return json.loads(raw.decode("utf-8"))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,6 +88,15 @@ def test_memory_save_and_timeline(client):
     assert any(m["timestamp"] == ts for m in timeline)
 
 
+def test_memory_file_encrypted(client, api_module):
+    resp = client.post("/memory/save", json={"text": "secret"})
+    ts = resp.json()["timestamp"]
+    safe_ts = ts.replace(":", "-")
+    path = api_module.MEMORY_DIR / f"{safe_ts}.json"
+    raw = path.read_bytes()
+    assert not raw.lstrip().startswith(b"{")
+
+
 def test_pending_and_complete(client, api_module):
     input_dir = api_module.INPUT_DIR
     processed_dir = api_module.PROCESSED_DIR


### PR DESCRIPTION
## Summary
- ignore research docs from git
- store persona data using Fernet encryption
- update API to encrypt profile and memory files
- check that memory files are encrypted
- depend on `cryptography`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f196d83688323b0b5f20dd196ae58