### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/src/digital_persona/api.py
+++ b/src/digital_persona/api.py
@@ -162,6 +162,9 @@ def create_app(interviewer: PersonalityInterviewer | None = None) -> FastAPI:
                 f"{processed_path.stem}-{ts}"
             )
         out_path = OUTPUT_DIR / (Path(req.file).stem + ".json")
+        out_path = out_path.resolve()
+        if not str(out_path).startswith(str(OUTPUT_DIR)):
+            raise HTTPException(status_code=400, detail="Invalid file path")
         in_path.rename(processed_path)
         with open(out_path, "w", encoding="utf-8") as f:
             json.dump(req.profile, f, indent=2)

--- a/src/digital_persona/api.py
+++ b/src/digital_persona/api.py
@@ -161,8 +161,7 @@ def create_app(interviewer: PersonalityInterviewer | None = None) -> FastAPI:
             processed_path = processed_path.with_stem(
                 f"{processed_path.stem}-{ts}"
             )
-        out_path = OUTPUT_DIR / (Path(req.file).stem + ".json")
-        out_path = out_path.resolve()
+        out_path = (OUTPUT_DIR / (Path(req.file).stem + ".json")).resolve()
         if not str(out_path).startswith(str(OUTPUT_DIR)):
             raise HTTPException(status_code=400, detail="Invalid file path")
         in_path.rename(processed_path)


### PR DESCRIPTION
Potential fix for [https://github.com/Hackshaven/digital-persona/security/code-scanning/8](https://github.com/Hackshaven/digital-persona/security/code-scanning/8)

To fix the issue, we need to validate and sanitize the user-provided `req.file` before using it to construct the `out_path`. The best approach is to normalize the constructed path using `os.path.normpath` or `Path.resolve()` and ensure it remains within the `OUTPUT_DIR`. If the normalized path does not start with `OUTPUT_DIR`, we should raise an exception to prevent unauthorized access.

Steps to implement the fix:
1. Normalize the constructed path using `Path.resolve()` to eliminate any `..` segments or symbolic links.
2. Check if the normalized path starts with `OUTPUT_DIR`. If not, raise an `HTTPException` with a 400 status code.
3. Apply this validation before using `out_path` in the `complete_interview` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
