### PR TITLE
Add Limitless ingest service

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -4,6 +4,8 @@
 # OpenAI or HuggingFace keys
 OPENAI_API_KEY=
 HF_API_KEY=
+# Force Ollama or OpenAI for the interviewer
+LLM_PROVIDER=ollama
 
 # Limitless API key
 LIMITLESS_API_KEY=

--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -9,6 +9,8 @@ HF_API_KEY=
 LIMITLESS_API_KEY=
 # Maximum days to fetch when no state is present
 LIMITLESS_LOOKBACK_DAYS=2
+# Comma-separated MCP plugin modules
+MCP_PLUGINS=digital_persona.mcp_plugins.limitless
 
 # Local Ollama server for LLMs
 OLLAMA_HOST=http://host.docker.internal:11434

--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -16,8 +16,6 @@ MCP_PLUGINS=digital_persona.mcp_plugins.limitless
 
 # Local Ollama server for LLMs
 OLLAMA_HOST=http://host.docker.internal:11434
-# OLLAMA_BASE_URL may also be used by some tools
-# OLLAMA_BASE_URL=http://host.docker.internal:11434
 OLLAMA_MODEL=llama3
 
 # Captioning and transcription defaults

--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -5,6 +5,11 @@
 OPENAI_API_KEY=
 HF_API_KEY=
 
+# Limitless API key
+LIMITLESS_API_KEY=
+# Maximum days to fetch when no state is present
+LIMITLESS_LOOKBACK_DAYS=2
+
 # Local Ollama server for LLMs
 OLLAMA_HOST=http://host.docker.internal:11434
 # OLLAMA_BASE_URL may also be used by some tools

--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -28,3 +28,6 @@ TRANSCRIBE_MODEL=
 
 # Ingest loop polling interval in seconds
 INGEST_INTERVAL=5
+
+# Store memories without encryption (development only)
+PLAINTEXT_MEMORIES=false

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The project is designed for interactive local development using either OpenAI or
    - Run a model (e.g., `ollama run llama3`).
    - Set environment variables:
      ```bash
-         export OLLAMA_HOST=http://localhost:11434  # or set OLLAMA_BASE_URL
+         export OLLAMA_HOST=http://localhost:11434
          export OLLAMA_MODEL=llama3
 
 Environment variables:
@@ -77,7 +77,7 @@ Environment variables:
 - `OPENAI_API_KEY` – API key for OpenAI models when using the `openai` provider.
 - `OPENAI_MODEL` – optional model name (e.g., `gpt-4o`).
 - `LLM_PROVIDER` – set to `ollama` or `openai` to override provider auto-detection.
-- `OLLAMA_BASE_URL` – base URL of your Ollama server (default `http://localhost:11434`).
+- `OLLAMA_HOST` – base URL of your Ollama server (default `http://localhost:11434`).
 - `OLLAMA_MODEL` – model name served by Ollama (e.g., `llama3`).
 - `PERSONA_DIR` – directory where the API stores encrypted profile and memory files.
 - `PERSONA_KEY` – optional symmetric key for encryption. If unset a key is created in `<PERSONA_DIR>/.persona.key`.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Environment variables:
 
 - `OPENAI_API_KEY` – API key for OpenAI models when using the `openai` provider.
 - `OPENAI_MODEL` – optional model name (e.g., `gpt-4o`).
+- `LLM_PROVIDER` – set to `ollama` or `openai` to override provider auto-detection.
 - `OLLAMA_BASE_URL` – base URL of your Ollama server (default `http://localhost:11434`).
 - `OLLAMA_MODEL` – model name served by Ollama (e.g., `llama3`).
 - `PERSONA_DIR` – directory where the API stores encrypted profile and memory files.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Environment variables:
 - `OLLAMA_MODEL` – model name served by Ollama (e.g., `llama3`).
 - `PERSONA_DIR` – directory where the API stores encrypted profile and memory files.
 - `PERSONA_KEY` – optional symmetric key for encryption. If unset a key is created in `<PERSONA_DIR>/.persona.key`.
+- `PLAINTEXT_MEMORIES` – set to `true` to disable encryption during development.
 
 3. **Install Dependencies**:
    - Run `poetry install --with dev --extras media` to set up the project locally.

--- a/persona_config.example.json
+++ b/persona_config.example.json
@@ -1,0 +1,3 @@
+{
+  "enabled_services": ["ingest", "limitless"]
+}

--- a/persona_config.example.json
+++ b/persona_config.example.json
@@ -1,3 +1,3 @@
 {
-  "enabled_services": ["ingest", "limitless"]
+  "enabled_services": ["ingest", "mcp"]
 }

--- a/scripts/start-services.py
+++ b/scripts/start-services.py
@@ -47,7 +47,7 @@ def main() -> None:
         launch([sys.executable, "-m", "digital_persona.ingest"], INGEST_LOG)
 
     if "limitless" in services:
-        launch([sys.executable, "-m", "digital_persona.limitless"], LIMITLESS_LOG)
+        launch([sys.executable, "-m", "plugins.limitless"], LIMITLESS_LOG)
 
 
 if __name__ == "__main__":

--- a/scripts/start-services.py
+++ b/scripts/start-services.py
@@ -5,10 +5,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+from digital_persona.config import enabled_services
+
 
 LOG_DIR = Path("/tmp")
 UVICORN_LOG = LOG_DIR / "uvicorn.log"
 INGEST_LOG = LOG_DIR / "ingest.log"
+LIMITLESS_LOG = LOG_DIR / "limitless.log"
 
 
 def launch(cmd: list[str], log_path: Path) -> None:
@@ -38,7 +41,13 @@ def main() -> None:
         UVICORN_LOG,
     )
 
-    launch([sys.executable, "-m", "digital_persona.ingest"], INGEST_LOG)
+    services = set(enabled_services())
+
+    if "ingest" in services:
+        launch([sys.executable, "-m", "digital_persona.ingest"], INGEST_LOG)
+
+    if "limitless" in services:
+        launch([sys.executable, "-m", "digital_persona.limitless"], LIMITLESS_LOG)
 
 
 if __name__ == "__main__":

--- a/scripts/start-services.py
+++ b/scripts/start-services.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from digital_persona.config import enabled_services
+from digital_persona.config import enabled_services, load_env
 
 
 LOG_DIR = Path("/tmp")
@@ -26,6 +26,7 @@ def launch(cmd: list[str], log_path: Path) -> None:
 
 
 def main() -> None:
+    load_env()
     launch(
         [
             sys.executable,

--- a/scripts/start-services.py
+++ b/scripts/start-services.py
@@ -11,7 +11,7 @@ from digital_persona.config import enabled_services, load_env
 LOG_DIR = Path("/tmp")
 UVICORN_LOG = LOG_DIR / "uvicorn.log"
 INGEST_LOG = LOG_DIR / "ingest.log"
-LIMITLESS_LOG = LOG_DIR / "limitless.log"
+MCP_LOG = LOG_DIR / "mcp.log"
 
 
 def launch(cmd: list[str], log_path: Path) -> None:
@@ -47,8 +47,8 @@ def main() -> None:
     if "ingest" in services:
         launch([sys.executable, "-m", "digital_persona.ingest"], INGEST_LOG)
 
-    if "limitless" in services:
-        launch([sys.executable, "-m", "plugins.limitless"], LIMITLESS_LOG)
+    if "mcp" in services:
+        launch([sys.executable, "-m", "digital_persona.mcp_server"], MCP_LOG)
 
 
 if __name__ == "__main__":

--- a/src/digital_persona/api.py
+++ b/src/digital_persona/api.py
@@ -16,6 +16,10 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
+from . import config as dp_config
+
+dp_config.load_env()
+
 from .interview import PersonalityInterviewer
 from .secure_storage import (
     get_fernet,

--- a/src/digital_persona/api.py
+++ b/src/digital_persona/api.py
@@ -94,7 +94,9 @@ class CompleteRequest(BaseModel):
 
 def create_app(interviewer: PersonalityInterviewer | None = None) -> FastAPI:
     if interviewer is None:
-        provider = "openai" if _valid_openai_key() else "ollama"
+        provider = os.getenv("LLM_PROVIDER")
+        if not provider:
+            provider = "openai" if _valid_openai_key() else "ollama"
         interviewer = PersonalityInterviewer(provider=provider)
     app = FastAPI()
     # StaticFiles requires an actual filesystem path

--- a/src/digital_persona/api.py
+++ b/src/digital_persona/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import json
 import shutil
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from importlib import resources
@@ -97,10 +98,12 @@ class CompleteRequest(BaseModel):
 
 
 def create_app(interviewer: PersonalityInterviewer | None = None) -> FastAPI:
+    dp_config.load_env()
     if interviewer is None:
-        provider = os.getenv("LLM_PROVIDER")
+        provider = os.getenv("LLM_PROVIDER", "").lower()
         if not provider:
             provider = "openai" if _valid_openai_key() else "ollama"
+        logging.info("Using %s provider for interviews", provider or "auto")
         interviewer = PersonalityInterviewer(provider=provider)
     app = FastAPI()
     # StaticFiles requires an actual filesystem path

--- a/src/digital_persona/config.py
+++ b/src/digital_persona/config.py
@@ -16,9 +16,19 @@ CONFIG_FILE = persona_dir() / "persona_config.json"
 
 
 def load_env() -> None:
-    """Load environment variables from a .env file if present."""
-    for name in (".env", ".devcontainer/.env"):
-        path = Path(name)
+    """Load environment variables from a .env file if present.
+
+    Searches the current directory and the project root so scripts can be
+    executed from any subdirectory during development.
+    """
+    root = persona_dir().parent
+    candidates = [
+        Path(".env"),
+        Path(".devcontainer/.env"),
+        root / ".env",
+        root / ".devcontainer/.env",
+    ]
+    for path in candidates:
         if path.exists():
             load_dotenv(path, override=False)
             break

--- a/src/digital_persona/config.py
+++ b/src/digital_persona/config.py
@@ -1,0 +1,34 @@
+import json
+import os
+from pathlib import Path
+
+
+def persona_dir() -> Path:
+    base = os.getenv("PERSONA_DIR")
+    if base:
+        return Path(base)
+    return Path(__file__).resolve().parents[2] / "persona"
+
+
+CONFIG_FILE = persona_dir() / "persona_config.json"
+
+
+def load_config() -> dict:
+    try:
+        text = CONFIG_FILE.read_text()
+        cfg = json.loads(text)
+        if isinstance(cfg, dict):
+            return cfg
+    except Exception:
+        pass
+    return {}
+
+
+def enabled_services(default: list[str] | None = None) -> list[str]:
+    env = os.getenv("ENABLED_SERVICES")
+    if env:
+        return [s.strip() for s in env.split(",") if s.strip()]
+    cfg = load_config()
+    if default is None:
+        default = ["ingest", "limitless"]
+    return cfg.get("enabled_services", default)

--- a/src/digital_persona/config.py
+++ b/src/digital_persona/config.py
@@ -2,6 +2,8 @@ import json
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 
 def persona_dir() -> Path:
     base = os.getenv("PERSONA_DIR")
@@ -11,6 +13,19 @@ def persona_dir() -> Path:
 
 
 CONFIG_FILE = persona_dir() / "persona_config.json"
+
+
+def load_env() -> None:
+    """Load environment variables from a .env file if present."""
+    for name in (".env", ".devcontainer/.env"):
+        path = Path(name)
+        if path.exists():
+            load_dotenv(path, override=False)
+            break
+
+
+# Load environment variables on import so other modules see them
+load_env()
 
 
 def load_config() -> dict:

--- a/src/digital_persona/config.py
+++ b/src/digital_persona/config.py
@@ -45,5 +45,5 @@ def enabled_services(default: list[str] | None = None) -> list[str]:
         return [s.strip() for s in env.split(",") if s.strip()]
     cfg = load_config()
     if default is None:
-        default = ["ingest", "limitless"]
+        default = ["ingest", "mcp"]
     return cfg.get("enabled_services", default)

--- a/src/digital_persona/ingest.py
+++ b/src/digital_persona/ingest.py
@@ -20,8 +20,8 @@ from .secure_storage import (
 )
 
 def _ollama_client():
-    """Return an Ollama client respecting OLLAMA_BASE_URL/OLLAMA_HOST."""
-    host = os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_HOST")
+    """Return an Ollama client respecting OLLAMA_HOST."""
+    host = os.getenv("OLLAMA_HOST")
     if host:
         import ollama
         return ollama.Client(host=host)

--- a/src/digital_persona/ingest.py
+++ b/src/digital_persona/ingest.py
@@ -483,18 +483,26 @@ def _analyze_sentiment(text: str) -> str:
     return ""
 
 
-def preprocess_text(path: Path) -> str:
+def preprocess_text(path: Path) -> tuple[str, Dict[str, Any], str | None]:
+    """Return sanitized text, parsed metadata, and optional timestamp."""
     text = path.read_text(encoding="utf-8", errors="ignore")
     suffix = path.suffix.lower()
+    meta: Dict[str, Any] = {}
+    ts: str | None = None
     if suffix in {".html", ".htm"}:
         text = _strip_html(text)
     elif suffix == ".json":
         try:
             obj = json.loads(text)
-            text = json.dumps(obj, ensure_ascii=False)
+            if isinstance(obj, dict) and "content" in obj:
+                text = obj.get("content", "")
+                ts = obj.get("timestamp")
+                meta = {k: v for k, v in obj.items() if k not in {"content"}}
+            else:
+                text = json.dumps(obj, ensure_ascii=False)
         except json.JSONDecodeError:
             pass
-    return _sanitize(text).strip()
+    return _sanitize(text).strip(), meta, ts
 
 
 def process_file(path: Path) -> bool:
@@ -577,14 +585,14 @@ def process_file(path: Path) -> bool:
             "source": str(dest.relative_to(PERSONA_DIR)),
         }
         else:
-            content = preprocess_text(path)
+            content, meta_extra, ts_override = preprocess_text(path)
             mem_obj = {
             "@context": "https://www.w3.org/ns/activitystreams",
             "type": "Note",
             "name": path.name,
             "content": content,
-            "metadata": {},
-            "timestamp": ts,
+            "metadata": meta_extra,
+            "timestamp": ts_override or ts,
             "source": str(dest.relative_to(PERSONA_DIR)),
         }
 

--- a/src/digital_persona/interview.py
+++ b/src/digital_persona/interview.py
@@ -32,7 +32,7 @@ class PersonalityInterviewer:
         self,
         llm: object | None = None,
         num_questions: int | None = None,
-        provider: str = "openai",
+        provider: str = "ollama",
         model: str | None = None,
         max_question_len: int = 300,
     ) -> None:
@@ -414,7 +414,7 @@ def _cli() -> None:
         "-n", "--questions", type=int, help="Number of questions to ask"
     )
     parser.add_argument(
-        "-p", "--provider", choices=["openai", "ollama"], default="openai"
+        "-p", "--provider", choices=["openai", "ollama"], default="ollama"
     )
     parser.add_argument("-m", "--model", help="Model name for the chosen provider")
     parser.add_argument(

--- a/src/digital_persona/interview.py
+++ b/src/digital_persona/interview.py
@@ -356,8 +356,8 @@ class PersonalityInterviewer:
         clean = response.strip()
 
         # Optional debug log
-        print("[DEBUG] Raw LLM response:")
-        print(clean)
+        # print("[DEBUG] Raw LLM response:")
+        # print(clean)
 
         # Strip markdown code blocks
         for prefix in ["```json", "```"]:

--- a/src/digital_persona/interview.py
+++ b/src/digital_persona/interview.py
@@ -70,7 +70,7 @@ class PersonalityInterviewer:
     def _create_llm(self, provider: str, model: str | None) -> object:
         """Return a language model instance for the chosen provider."""
         if provider.lower() == "ollama":
-            base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+            base_url = os.getenv("OLLAMA_HOST", "http://localhost:11434")
             model_name = model or os.getenv("OLLAMA_MODEL", "gemma3:12b")
             return ChatOllama(base_url=base_url, model=model_name)
         else:

--- a/src/digital_persona/limitless.py
+++ b/src/digital_persona/limitless.py
@@ -1,0 +1,106 @@
+import json
+import os
+import logging
+from pathlib import Path
+from datetime import datetime, timedelta
+import time
+import httpx
+
+from .ingest import INPUT_DIR, _persona_dir
+
+STATE_FILE = _persona_dir() / "limitless_state.json"
+API_URL = os.getenv("LIMITLESS_API_URL", "https://api.limitless.ai/v1")
+API_KEY = os.getenv("LIMITLESS_API_KEY")
+if not API_KEY:
+    raise RuntimeError(
+        "LIMITLESS_API_KEY environment variable is required to use Limitless ingest"
+    )
+POLL_INTERVAL = float(os.getenv("LIMITLESS_POLL_INTERVAL", "300"))
+LOOKBACK_DAYS = int(os.getenv("LIMITLESS_LOOKBACK_DAYS", "2"))
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+
+
+def _load_state() -> dict:
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_state(state: dict) -> None:
+    STATE_FILE.write_text(json.dumps(state))
+
+
+def _fetch_entries(*, since: str | None = None, since_id: str | None = None) -> list[dict]:
+    headers = {"Authorization": f"Bearer {API_KEY}"}
+    params = {}
+    if since:
+        params["since"] = since
+    if since_id:
+        params["sinceId"] = since_id
+    url = f"{API_URL.rstrip('/')}/memories"
+    resp = httpx.get(url, headers=headers, params=params, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    if isinstance(data, dict):
+        data = data.get("items", [])
+    return data
+
+
+def _save_entry(entry: dict) -> None:
+    entry_id = entry.get("id") or entry.get("uuid") or entry.get("timestamp")
+    if not entry_id:
+        entry_id = datetime.utcnow().timestamp()
+    out = INPUT_DIR / f"limitless-{entry_id}.json"
+    obj = {k: v for k, v in entry.items()}
+    out.write_text(json.dumps(obj, ensure_ascii=False), encoding="utf-8")
+    logger.info("Saved %s", out.name)
+
+
+def run_once() -> None:
+    state = _load_state()
+    last_id: str | None = state.get("last_id")
+    since: str | None = state.get("since")
+
+    if last_id and not (INPUT_DIR / f"limitless-{last_id}.json").exists():
+        last_id = None
+
+    if not last_id and not since:
+        since = (datetime.utcnow() - timedelta(days=LOOKBACK_DAYS)).isoformat() + "Z"
+
+    try:
+        entries = _fetch_entries(since=since, since_id=last_id)
+    except Exception:
+        logger.exception("Failed to fetch entries")
+        return
+    latest_ts = since
+    latest_id = last_id
+    for e in entries:
+        _save_entry(e)
+        ts = e.get("timestamp")
+        if ts and (latest_ts is None or ts > latest_ts):
+            latest_ts = ts
+        eid = e.get("id") or e.get("uuid") or e.get("timestamp")
+        if eid:
+            latest_id = eid
+    if latest_ts:
+        state["since"] = latest_ts
+    if latest_id:
+        state["last_id"] = latest_id
+    _save_state(state)
+
+
+def _cli() -> None:
+    logger.info("Starting Limitless ingest loop (interval=%s)", POLL_INTERVAL)
+    while True:
+        run_once()
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/src/digital_persona/mcp_plugins/limitless.py
+++ b/src/digital_persona/mcp_plugins/limitless.py
@@ -81,10 +81,14 @@ def _save_entry(entry: dict) -> None:
     if not entry_id:
         entry_id = datetime.now(UTC).timestamp()
     entry_id = str(entry_id).replace(".", "")  # Remove decimal point if present
-    out = INPUT_DIR / f"limitless-{entry_id}.json"
+    out = _get_entry_filename(entry_id)
     obj = {k: v for k, v in entry.items()}
     out.write_text(json.dumps(obj, ensure_ascii=False), encoding="utf-8")
     logger.info("Saved %s", out.name)
+
+def _get_entry_filename(entry_id) -> os.PathLike:
+    """Construct the file path for a given entry ID."""
+    return INPUT_DIR / f"limitless-{entry_id}.json"
 
 
 def run_once() -> None:
@@ -93,7 +97,7 @@ def run_once() -> None:
     cursor: str | None = state.get("cursor")
     start: str | None = state.get("start")
 
-    if last_id and not (INPUT_DIR / f"limitless-{last_id}.json").exists():
+    if last_id and not _get_entry_filename(last_id).exists():
         last_id = None
 
     if not cursor and not start:

--- a/src/digital_persona/mcp_plugins/limitless.py
+++ b/src/digital_persona/mcp_plugins/limitless.py
@@ -54,7 +54,7 @@ def _save_state(state: dict) -> None:
 
 
 def _fetch_entries(*, since: str | None = None, since_id: str | None = None) -> list[dict]:
-    headers = {"Authorization": f"Bearer {API_KEY}"}
+    headers = {"X-API-Key": API_KEY}
     params = {}
     if since:
         params["since"] = since

--- a/src/digital_persona/mcp_plugins/limitless.py
+++ b/src/digital_persona/mcp_plugins/limitless.py
@@ -80,6 +80,7 @@ def _save_entry(entry: dict) -> None:
     entry_id = entry.get("id") or entry.get("uuid") or entry.get("timestamp")
     if not entry_id:
         entry_id = datetime.now(UTC).timestamp()
+    entry_id = str(entry_id).replace(".", "")  # Remove decimal point if present
     out = INPUT_DIR / f"limitless-{entry_id}.json"
     obj = {k: v for k, v in entry.items()}
     out.write_text(json.dumps(obj, ensure_ascii=False), encoding="utf-8")

--- a/src/digital_persona/mcp_plugins/limitless.py
+++ b/src/digital_persona/mcp_plugins/limitless.py
@@ -1,7 +1,7 @@
 import json
 import os
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import asyncio
 import httpx
 from fastapi import APIRouter, FastAPI
@@ -79,7 +79,7 @@ def _fetch_entries(*, start: str | None = None, cursor: str | None = None) -> tu
 def _save_entry(entry: dict) -> None:
     entry_id = entry.get("id") or entry.get("uuid") or entry.get("timestamp")
     if not entry_id:
-        entry_id = datetime.utcnow().timestamp()
+        entry_id = datetime.now(UTC).timestamp()
     out = INPUT_DIR / f"limitless-{entry_id}.json"
     obj = {k: v for k, v in entry.items()}
     out.write_text(json.dumps(obj, ensure_ascii=False), encoding="utf-8")
@@ -96,7 +96,7 @@ def run_once() -> None:
         last_id = None
 
     if not cursor and not start:
-        start = (datetime.utcnow() - timedelta(days=LOOKBACK_DAYS)).isoformat() + "Z"
+        start = (datetime.now(UTC) - timedelta(days=LOOKBACK_DAYS)).isoformat().replace("+00:00", "Z")
 
     try:
         entries, next_cursor = _fetch_entries(start=start, cursor=cursor)

--- a/src/digital_persona/mcp_plugins/limitless.py
+++ b/src/digital_persona/mcp_plugins/limitless.py
@@ -60,7 +60,7 @@ def _fetch_entries(*, since: str | None = None, since_id: str | None = None) -> 
         params["since"] = since
     if since_id:
         params["sinceId"] = since_id
-    url = f"{API_URL.rstrip('/')}/memories"
+    url = f"{API_URL.rstrip('/')}/lifelogs"
     resp = httpx.get(url, headers=headers, params=params, timeout=30)
     resp.raise_for_status()
     data = resp.json()
@@ -114,8 +114,8 @@ def run_once() -> None:
     _save_state(state)
 
 
-@router.get("/memories")
-async def api_memories(since: str | None = None, since_id: str | None = None) -> dict:
+@router.get("/lifelogs")
+async def api_lifelogs(since: str | None = None, since_id: str | None = None) -> dict:
     """Return Limitless entries via the MCP server."""
     items = _fetch_entries(since=since, since_id=since_id)
     return {"items": items}

--- a/src/digital_persona/mcp_server.py
+++ b/src/digital_persona/mcp_server.py
@@ -1,0 +1,38 @@
+import os
+import importlib
+from fastapi import FastAPI
+
+DEFAULT_PLUGINS = ["digital_persona.mcp_plugins.limitless"]
+
+
+def create_app(plugin_names: list[str] | None = None) -> FastAPI:
+    if plugin_names is None:
+        env = os.getenv("MCP_PLUGINS")
+        if env:
+            plugin_names = [p.strip() for p in env.split(",") if p.strip()]
+        else:
+            plugin_names = DEFAULT_PLUGINS
+
+    app = FastAPI(title="MCP Server")
+    for name in plugin_names:
+        try:
+            mod = importlib.import_module(name)
+        except Exception:
+            continue
+        router = getattr(mod, "router", None)
+        if router is not None:
+            prefix = "/" + name.split(".")[-1]
+            app.include_router(router, prefix=prefix)
+    return app
+
+
+def _cli() -> None:
+    import uvicorn
+
+    app = create_app()
+    port = int(os.getenv("MCP_PORT", "8900"))
+    uvicorn.run(app, host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/src/digital_persona/mcp_server.py
+++ b/src/digital_persona/mcp_server.py
@@ -22,8 +22,8 @@ def create_app(plugin_names: list[str] | None = None) -> FastAPI:
     for name in plugin_names:
         try:
             mod = importlib.import_module(name)
-        except Exception:
-            logger.exception("Failed to import plugin %s", name)
+        except Exception as e:
+            logger.exception("Failed to import plugin %s: %s", name, str(e))
             continue
         router = getattr(mod, "router", None)
         if router is not None:

--- a/src/plugins/limitless.py
+++ b/src/plugins/limitless.py
@@ -1,12 +1,11 @@
 import json
 import os
 import logging
-from pathlib import Path
 from datetime import datetime, timedelta
 import time
 import httpx
 
-from .ingest import INPUT_DIR, _persona_dir
+from digital_persona.ingest import INPUT_DIR, _persona_dir
 
 STATE_FILE = _persona_dir() / "limitless_state.json"
 API_URL = os.getenv("LIMITLESS_API_URL", "https://api.limitless.ai/v1")

--- a/src/plugins/limitless.py
+++ b/src/plugins/limitless.py
@@ -5,6 +5,9 @@ from datetime import datetime, timedelta
 import time
 import httpx
 
+from digital_persona import config as dp_config
+
+dp_config.load_env()
 from digital_persona.ingest import INPUT_DIR, _persona_dir
 
 STATE_FILE = _persona_dir() / "limitless_state.json"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -133,3 +133,19 @@ def test_start_interview_bad_memory_file(client, api_module):
     assert "Invalid memory file" in resp.json()["detail"]
 
 
+def test_create_app_respects_env(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    captured = {}
+
+    class DummyInterviewer:
+        def __init__(self, provider=None, **kwargs):
+            captured["provider"] = provider
+
+    monkeypatch.setattr("digital_persona.interview.PersonalityInterviewer", DummyInterviewer)
+    import importlib
+    import digital_persona.api as api
+    api = importlib.reload(api)
+    api.create_app()
+    assert captured["provider"] == "ollama"
+
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,20 @@
+import importlib
+from pathlib import Path
+import json
+
+from digital_persona import config
+
+
+def test_enabled_services_env(monkeypatch):
+    monkeypatch.setenv("ENABLED_SERVICES", "foo,bar")
+    assert config.enabled_services() == ["foo", "bar"]
+
+
+def test_enabled_services_file(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("ENABLED_SERVICES", raising=False)
+    monkeypatch.setenv("PERSONA_DIR", str(tmp_path))
+    cfg = {"enabled_services": ["x", "y"]}
+    (tmp_path / "persona_config.json").write_text(json.dumps(cfg))
+    importlib.reload(config)
+    assert config.enabled_services() == ["x", "y"]
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 from pathlib import Path
 import json
 
@@ -17,4 +18,21 @@ def test_enabled_services_file(monkeypatch, tmp_path: Path):
     (tmp_path / "persona_config.json").write_text(json.dumps(cfg))
     importlib.reload(config)
     assert config.enabled_services() == ["x", "y"]
+
+
+def test_load_env_searches_project_root(monkeypatch, tmp_path: Path):
+    # create fake project structure with .env at root
+    env_path = tmp_path / ".env"
+    env_path.write_text("TEST_VAL=1\n")
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+
+    monkeypatch.chdir(scripts)
+    monkeypatch.setenv("PERSONA_DIR", str(tmp_path / "persona"))
+    monkeypatch.delenv("TEST_VAL", raising=False)
+
+    import importlib
+    importlib.reload(config)
+
+    assert os.getenv("TEST_VAL") == "1"
 

--- a/tests/test_interviewer.py
+++ b/tests/test_interviewer.py
@@ -193,7 +193,7 @@ def test_profile_from_answers_invalid_json_error():
     interviewer = PersonalityInterviewer(llm=llm)
     with pytest.raises(ValueError) as exc:
         interviewer.profile_from_answers("ctx", ["Q: ?\nA: ."])
-    assert "not valid JSON" in str(exc.value)
+    assert "Expected JSON object" in str(exc.value)
 
 
 def test_run_allows_early_finish(monkeypatch):

--- a/tests/test_interviewer.py
+++ b/tests/test_interviewer.py
@@ -39,7 +39,7 @@ if "langchain" not in sys.modules:
 # Project import (source assumed in ../src)
 # -------------------------------------------------------------------------
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-from digital_persona.interview import PersonalityInterviewer, MAX_FOLLOWUPS
+from digital_persona.interview import MAX_FOLLOWUPS, PersonalityInterviewer
 
 
 # -------------------------------------------------------------------------
@@ -55,6 +55,20 @@ class StubLLM:
     invoke = __call__  # Allow .invoke(...) as well
 
 
+class RecordingLLM(StubLLM):
+    def __init__(self, responses):
+        super().__init__(responses)
+        self.call_count = 0
+        self.last = None
+
+    def __call__(self, messages):
+        self.call_count += 1
+        self.last = messages
+        return super().__call__(messages)
+
+    invoke = __call__
+
+
 # -------------------------------------------------------------------------
 # Tests
 # -------------------------------------------------------------------------
@@ -63,6 +77,17 @@ def test_generate_questions_parses_lines():
     interviewer = PersonalityInterviewer(llm=llm, num_questions=3)
     qs = interviewer.generate_questions("notes")
     assert qs == ["Q1?", "Q2?", "Q3?"]
+
+
+def test_generate_questions_chunks_long_notes():
+    tmp = PersonalityInterviewer(llm=StubLLM([]))
+    long_notes = "x" * (tmp.MAX_NOTES_CHARS + 10)
+    responses = ["sum1", "sum2", "Q?"]
+    llm = RecordingLLM(responses)
+    interviewer = PersonalityInterviewer(llm=llm, num_questions=1)
+    qs = interviewer.generate_questions(long_notes)
+    assert qs == ["Q?"]
+    assert llm.call_count > 1
 
 
 def test_default_question_count_half_traits():
@@ -176,13 +201,20 @@ def test_run_allows_early_finish(monkeypatch):
         "Summary",  # summarize_data
         "Q1?\nQ2?",  # generate_questions
         "Expl",  # explain_question for Q1
-        json.dumps({
-            "traits": {"openness": 0.1, "conscientiousness": 0.2,
-                        "extraversion": 0.3, "agreeableness": 0.4,
-                        "neuroticism": 0.5, "honestyHumility": 0.6},
-            "userID": "anon02",
-            "psychologicalSummary": "Done"
-        })
+        json.dumps(
+            {
+                "traits": {
+                    "openness": 0.1,
+                    "conscientiousness": 0.2,
+                    "extraversion": 0.3,
+                    "agreeableness": 0.4,
+                    "neuroticism": 0.5,
+                    "honestyHumility": 0.6,
+                },
+                "userID": "anon02",
+                "psychologicalSummary": "Done",
+            }
+        ),
     ]
     llm = StubLLM(responses)
     interviewer = PersonalityInterviewer(llm=llm, num_questions=2)
@@ -203,18 +235,20 @@ def test_run_simulated_generates_profile(capsys):
         "Expl",  # explain_question
         "Auto",  # simulate_answer
         "NO FOLLOWUP",  # generate_followup
-        json.dumps({
-            "traits": {
-                "openness": 0.1,
-                "conscientiousness": 0.2,
-                "extraversion": 0.3,
-                "agreeableness": 0.4,
-                "neuroticism": 0.5,
-                "honestyHumility": 0.6,
-            },
-            "userID": "anon03",
-            "psychologicalSummary": "Done",
-        })
+        json.dumps(
+            {
+                "traits": {
+                    "openness": 0.1,
+                    "conscientiousness": 0.2,
+                    "extraversion": 0.3,
+                    "agreeableness": 0.4,
+                    "neuroticism": 0.5,
+                    "honestyHumility": 0.6,
+                },
+                "userID": "anon03",
+                "psychologicalSummary": "Done",
+            }
+        ),
     ]
     llm = StubLLM(responses)
     interviewer = PersonalityInterviewer(llm=llm, num_questions=1)

--- a/tests/test_limitless.py
+++ b/tests/test_limitless.py
@@ -10,7 +10,7 @@ import pytest
 def setup_limitless(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("PERSONA_DIR", str(tmp_path))
     monkeypatch.setenv("LIMITLESS_API_KEY", "test-key")
-    import digital_persona.limitless as limitless
+    import plugins.limitless as limitless
     limitless = importlib.reload(limitless)
     return limitless
 
@@ -41,7 +41,7 @@ def test_requires_api_key(monkeypatch, tmp_path):
     monkeypatch.delenv("LIMITLESS_API_KEY", raising=False)
     with pytest.raises(RuntimeError):
         import importlib as _imp
-        _imp.reload(_imp.import_module("digital_persona.limitless"))
+        _imp.reload(_imp.import_module("plugins.limitless"))
 
 
 def test_default_since_lookback(monkeypatch, tmp_path):

--- a/tests/test_limitless.py
+++ b/tests/test_limitless.py
@@ -1,6 +1,6 @@
 import importlib
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, UTC
 
 import json
 
@@ -58,7 +58,7 @@ def test_default_start_lookback(monkeypatch, tmp_path):
     limitless.run_once()
 
     assert captured["start"] is not None
-    delta = datetime.utcnow() - datetime.fromisoformat(captured["start"].replace("Z", ""))
+    delta = datetime.now(UTC) - datetime.fromisoformat(captured["start"].replace("Z", "+00:00"))
     assert 0 <= delta.days <= 2
 
 

--- a/tests/test_limitless.py
+++ b/tests/test_limitless.py
@@ -10,7 +10,7 @@ import pytest
 def setup_limitless(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("PERSONA_DIR", str(tmp_path))
     monkeypatch.setenv("LIMITLESS_API_KEY", "test-key")
-    import plugins.limitless as limitless
+    import digital_persona.mcp_plugins.limitless as limitless
     limitless = importlib.reload(limitless)
     return limitless
 
@@ -41,7 +41,7 @@ def test_requires_api_key(monkeypatch, tmp_path):
     monkeypatch.delenv("LIMITLESS_API_KEY", raising=False)
     with pytest.raises(RuntimeError):
         import importlib as _imp
-        _imp.reload(_imp.import_module("plugins.limitless"))
+        _imp.reload(_imp.import_module("digital_persona.mcp_plugins.limitless"))
 
 
 def test_default_since_lookback(monkeypatch, tmp_path):

--- a/tests/test_limitless.py
+++ b/tests/test_limitless.py
@@ -1,0 +1,82 @@
+import importlib
+from pathlib import Path
+from datetime import datetime
+
+import json
+
+import pytest
+
+
+def setup_limitless(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("PERSONA_DIR", str(tmp_path))
+    monkeypatch.setenv("LIMITLESS_API_KEY", "test-key")
+    import digital_persona.limitless as limitless
+    limitless = importlib.reload(limitless)
+    return limitless
+
+
+def test_run_once_saves_files(monkeypatch, tmp_path):
+    limitless = setup_limitless(monkeypatch, tmp_path)
+
+    def fake_fetch(*, since=None, since_id=None):
+        return [
+            {"id": "1", "content": "hello", "timestamp": "2025-07-07T00:00:00Z"}
+        ]
+
+    monkeypatch.setattr(limitless, "_fetch_entries", fake_fetch)
+    limitless.run_once()
+
+    files = list(limitless.INPUT_DIR.glob("limitless-*.json"))
+    assert files
+    data = json.loads(files[0].read_text())
+    assert data["content"] == "hello"
+
+    state = json.loads((tmp_path / "limitless_state.json").read_text())
+    assert state["since"] == "2025-07-07T00:00:00Z"
+    assert state["last_id"] == "1"
+
+
+def test_requires_api_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("PERSONA_DIR", str(tmp_path))
+    monkeypatch.delenv("LIMITLESS_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        import importlib as _imp
+        _imp.reload(_imp.import_module("digital_persona.limitless"))
+
+
+def test_default_since_lookback(monkeypatch, tmp_path):
+    limitless = setup_limitless(monkeypatch, tmp_path)
+
+    captured = {}
+
+    def fake_fetch(*, since=None, since_id=None):
+        captured["since"] = since
+        captured["since_id"] = since_id
+        return []
+
+    monkeypatch.setattr(limitless, "_fetch_entries", fake_fetch)
+    limitless.run_once()
+
+    assert captured["since"] is not None
+    delta = datetime.utcnow() - datetime.fromisoformat(captured["since"].replace("Z", ""))
+    assert 0 <= delta.days <= 2
+
+
+def test_missing_file_triggers_redownload(monkeypatch, tmp_path):
+    limitless = setup_limitless(monkeypatch, tmp_path)
+
+    state_file = tmp_path / "limitless_state.json"
+    state_file.write_text(json.dumps({"last_id": "99", "since": "2025-07-01T00:00:00Z"}))
+    captured = {}
+
+    def fake_fetch(*, since=None, since_id=None):
+        captured["since"] = since
+        captured["since_id"] = since_id
+        return []
+
+    monkeypatch.setattr(limitless, "_fetch_entries", fake_fetch)
+    limitless.run_once()
+
+    assert captured["since"] is not None
+    assert captured["since_id"] is None
+

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,6 +16,6 @@ def test_limitless_route(monkeypatch, tmp_path: Path):
     importlib.reload(mcp_server)
     app = mcp_server.create_app()
     client = TestClient(app)
-    resp = client.get("/limitless/memories")
+    resp = client.get("/limitless/lifelogs")
     assert resp.status_code == 200
     assert resp.json()["items"][0]["content"] == "hi"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10,7 +10,7 @@ def test_limitless_route(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("MCP_PLUGINS", "digital_persona.mcp_plugins.limitless")
 
     import digital_persona.mcp_plugins.limitless as limitless
-    monkeypatch.setattr(limitless, "_fetch_entries", lambda since=None, since_id=None: [{"id": "1", "content": "hi"}])
+    monkeypatch.setattr(limitless, "_fetch_entries", lambda start=None, cursor=None: ([{"id": "1", "content": "hi"}], None))
 
     from digital_persona import mcp_server
     importlib.reload(mcp_server)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,21 @@
+import importlib
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def test_limitless_route(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("PERSONA_DIR", str(tmp_path))
+    monkeypatch.setenv("LIMITLESS_API_KEY", "x")
+    monkeypatch.setenv("MCP_PLUGINS", "digital_persona.mcp_plugins.limitless")
+
+    import digital_persona.mcp_plugins.limitless as limitless
+    monkeypatch.setattr(limitless, "_fetch_entries", lambda since=None, since_id=None: [{"id": "1", "content": "hi"}])
+
+    from digital_persona import mcp_server
+    importlib.reload(mcp_server)
+    app = mcp_server.create_app()
+    client = TestClient(app)
+    resp = client.get("/limitless/memories")
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["content"] == "hi"


### PR DESCRIPTION
## Summary
- support metadata extraction when ingesting JSON files
- add background service for fetching Limitless AI memories
- include service launch in `start-services.py`
- test metadata handling and Limitless ingest logic
- add config module and example persona config
- enforce LIMITLESS_API_KEY in Limitless ingest
- add lookback days and file recovery logic for Limitless service

## Testing
- `pytest tests/test_limitless.py tests/test_ingest.py tests/test_config.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686b50d6040083239e8767fb4a212d77